### PR TITLE
0.0.21-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "istanbul": "^0.4.0",
     "istanbul-coveralls": "^1.0.3",
     "mocha": "^2.3.3",
-    "mocha-phantomjs": "^4.0.1",
+    "mocha-phantomjs": "^4.1.0",
     "mocha-phantomjs-istanbul": "0.0.2",
     "should": "^7.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clearest",
-  "version": "0.0.20-alpha",
+  "version": "0.0.21-alpha",
   "description": "Clearest Framework",
   "main": "index.js",
   "repository": {

--- a/test/tool/xvdl.js
+++ b/test/tool/xvdl.js
@@ -326,7 +326,7 @@ describe('tool / xvdl instructions', function () {
     it("s:*", function () {
         //TODO: $filter
         //TODO: $bind
-        //TODO: $orderby
+
 
         compiler.compile(dom.parseFromString('<s:bar/>'))
             .should.be.exactly('S(P.sel($context,"bar"))');
@@ -350,6 +350,27 @@ describe('tool / xvdl instructions', function () {
 
         compiler.compile(dom.parseFromString('<s:bar from="foo" where="bar-expression" orderby="order-expression"><t:context/></s:bar>'))
             .should.be.exactly('S(P.sel(foo,"bar",function(bar,bar$index){return bar},function(bar,bar$index){return bar-expression},function(bar,bar$index){return order-expression}))');
+
+        // $order-function
+
+        compiler.compile(dom.parseFromString('<s:bar from="foo" order="myfun"><t:context/></s:bar>'))
+            .should.be.exactly('S(P.sel(foo,"bar",function(bar,bar$index){return bar},false,myfun))');
+
+        compiler.compile(dom.parseFromString('<s:bar from="foo" where="bar-expression" order="myfun"><t:context/></s:bar>'))
+            .should.be.exactly('S(P.sel(foo,"bar",function(bar,bar$index){return bar},function(bar,bar$index){return bar-expression},myfun))');
+
+    });
+
+    // alternative to s:* with explicit syntax
+    it("t:select", function () {
+
+        // direct js
+        compiler.compile(dom.parseFromString('<t:select property="foo+bar"/>'))
+            .should.be.exactly('S(P.sel($context,foo+bar))');
+
+       // sub-select expression
+        compiler.compile(dom.parseFromString('<t:select property="{{bar}}" from="foo"/>'))
+            .should.be.exactly('S(P.get(function($1){return P.sel(foo,$1)},[P.sel($context,"bar")]))');
 
     });
 

--- a/tool/stream.js
+++ b/tool/stream.js
@@ -159,22 +159,24 @@ module.exports = {
 
             file.path = processor.outputFilename(file.path);    // rename output file (as compiler/processor would see it)
 
+	    var noop = function(e){return e;}
             var opts = {
                 currentLocation: originalPath,
                 // extend environment vaiables with path information
                 environment: extend(true,
-                    config.environment, {
+                    config.environment, (config.computeEnvironment||noop)({
                         source: {
                             file: path.basename(originalPath),
                             path: originalPath,
-                            dir: path.dirname(originalPath)
+                            dir: path.dirname(originalPath),
+			    rel: file.relative
                         },
                         target: {
                             file: path.basename(file.path),
                             path: file.path,
                             dir: config.targetDir
                         }
-                    })
+                    }))
             };
 
             if (config.targetDir)


### PR DESCRIPTION
- Breaking change: attribute prefix is changed from @ to $.
- Minor refactoring
- Added t:ignore and t:import instructions.
- Extended t:use instruction with @from="source|scope" attribute, so the
  pattern
  <t:import myTemplate=".../someTemplate.xml"/>
  ...
  <t:use template="myTemplate" from="scope"> ... /t:use
  is equivalent to
  <t:use template=".../someTemplate.xml">.../t:use
  - Added @order=<function> attribute for select instructions (@order-by=<expression> remains as an alternative)
